### PR TITLE
개별 기사 페이지 생성

### DIFF
--- a/app/[category]/page.tsx
+++ b/app/[category]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { CategoryNewsData } from "../data/categoryNewsData";
+import Link from "next/link";
 import Loading from "../components/loading";
 import { NewsData } from "../types/news";
 import { useParams } from "next/navigation";
@@ -37,16 +38,49 @@ export default function CategoryPage() {
     <div>
       {data.map((article: NewsData, index) => (
         <div key={index} className="border py-6 px-4 rounded-md flex">
-          <div className="w-[60%] px-4">
-            <h2 className="text-[1.4rem] font-bold mb-4">{article.title}</h2>
-            <p>{article.description}</p>
+          <div className="w-[60%] px-4 flex flex-col justify-between">
+            <Link
+              href={{
+                pathname: "/article",
+                query: {
+                  title: article.title,
+                  content: article.content,
+                  urlToImage: article.urlToImage,
+                  publishedAt: article.publishedAt,
+                  publishName: article.source.name,
+                  url: article.url,
+                },
+              }}
+            >
+              <div>
+                <h2 className="text-[1.4rem] font-bold mb-4 hover:underline">
+                  {article.title}
+                </h2>
+                <p className="hover:underline">{article.description}</p>
+              </div>
+            </Link>
+            <p className="font-bold text-blue-600">{article.source.name}</p>
           </div>
           <div className="relative w-[40%] h-[300px]">
-            <img
-              src={article.urlToImage}
-              alt="news Image"
-              className="w-full h-full object-cover rounded-md"
-            />
+            <Link
+              href={{
+                pathname: "/article",
+                query: {
+                  title: article.title,
+                  content: article.content,
+                  urlToImage: article.urlToImage,
+                  publishedAt: article.publishedAt,
+                  publishName: article.source.name,
+                  url: article.url,
+                },
+              }}
+            >
+              <img
+                src={article.urlToImage}
+                alt="news Image"
+                className="w-full h-full object-cover rounded-md"
+              />
+            </Link>
           </div>
         </div>
       ))}

--- a/app/article/page.tsx
+++ b/app/article/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { DateFormat } from "../utils/dateFormat";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+
+export default function ArticlePage() {
+  const searchParams = useSearchParams();
+
+  const title = searchParams.get("title");
+  const publishedAt = searchParams.get("publishedAt") ?? "2025-01-07T16:00:00Z";
+  const urlToImage = searchParams.get("urlToImage");
+  const content = searchParams.get("content");
+  const publishName = searchParams.get("publishName");
+  const url = searchParams.get("url");
+
+  return (
+    <div className="px-16 py-8 w-[80%] mx-auto mb-12">
+      <h1 className="text-[2rem] font-bold mb-8">{title}</h1>
+      {urlToImage && (
+        <div className="relative mx-auto">
+          <img
+            src={urlToImage}
+            alt="news Image"
+            className="object-cover w-full h-full rounded-md mb-4"
+          />
+        </div>
+      )}
+      <p className="font-bold text-gray-700">{publishName}</p>
+      <p className="font-bold text-gray-700 text-[0.9rem]">
+        {DateFormat(publishedAt)}
+      </p>
+      <p className="my-4 text-[1.2rem]">{content}</p>
+      <Link href={`${url}`} target="_blank">
+        <p className="text-[1.1rem] font-bold">
+          Read more about the article :{" "}
+          <b className="border-b text-blue-600">{url}</b>
+        </p>
+      </Link>
+    </div>
+  );
+}

--- a/app/components/card/setionFour/cardSetion.tsx
+++ b/app/components/card/setionFour/cardSetion.tsx
@@ -1,6 +1,7 @@
 import { CardSectionProps } from "@/app/types/news";
 import { DateFormat } from "@/app/utils/dateFormat";
 import { FaUserCircle } from "react-icons/fa";
+import Link from "next/link";
 import React from "react";
 import { TextLimit } from "@/app/utils/textLimit";
 
@@ -8,28 +9,58 @@ export default function CardSetion({ data }: CardSectionProps) {
   return (
     <div className="py-4">
       <div className="relative w-[18rem] h-[200px] mx-auto">
-        <img
-          src={data.urlToImage}
-          alt="news Image"
-          className="w-full h-full object-cover rounded-md"
-        />
+        <Link
+          href={{
+            pathname: "/article",
+            query: {
+              title: data.title,
+              content: data.content,
+              urlToImage: data.urlToImage,
+              publishedAt: data.publishedAt,
+              publishName: data.source.name,
+              url: data.url,
+            },
+          }}
+        >
+          <img
+            src={data.urlToImage}
+            alt="news Image"
+            className="w-full h-full object-cover rounded-md"
+          />
+        </Link>
       </div>
-      <div className="flex items-center w-[18rem] mx-auto text-[0.9rem] pt-4">
-        <FaUserCircle className="w-8 h-8 mr-4 text-blue-300" />
-        <div className="flex flex-col">
-          <span className="font-semibold ">
-            {TextLimit(data.author, 20) || "Frenkie De Jong"}
-          </span>
-          <span className="text-gray-600">author</span>
+      <Link
+        href={{
+          pathname: "/article",
+          query: {
+            title: data.title,
+            content: data.content,
+            urlToImage: data.urlToImage,
+            publishedAt: data.publishedAt,
+            publishName: data.source.name,
+            url: data.url,
+          },
+        }}
+      >
+        <div className="flex items-center w-[18rem] mx-auto text-[0.9rem] pt-4 pb-2 hover:underline">
+          <FaUserCircle className="w-8 h-8 mr-4 text-blue-300" />
+          <div className="flex flex-col">
+            <span className="font-semibold ">
+              {TextLimit(data.author, 20) || "Frenkie De Jong"}
+            </span>
+            <span className="text-gray-600">author</span>
+          </div>
         </div>
-      </div>
-      <div className="w-[18rem] mx-auto">
-        <h1 className="font-bold text-[0.9rem]">{TextLimit(data.title, 60)}</h1>
-        <span className="flex my-4 text-gray-600 text-[0.8rem]">
-          <p className="mr-2 font-bold text-orange-300">{data.source.name}</p>
-          {`| ${DateFormat(data.publishedAt)}`}
-        </span>
-      </div>
+        <div className="w-[18rem] mx-auto hover:underline">
+          <h1 className="font-bold text-[0.9rem]">
+            {TextLimit(data.title, 60)}
+          </h1>
+          <span className="flex my-4 text-gray-600 text-[0.8rem]">
+            <p className="mr-2 font-bold text-orange-300">{data.source.name}</p>
+            {`| ${DateFormat(data.publishedAt)}`}
+          </span>
+        </div>
+      </Link>
     </div>
   );
 }

--- a/app/components/card/setionOne/cardSetionOne.tsx
+++ b/app/components/card/setionOne/cardSetionOne.tsx
@@ -1,6 +1,7 @@
 import { CardSectionProps } from "@/app/types/news";
 import { DateFormat } from "@/app/utils/dateFormat";
 import { FaUserCircle } from "react-icons/fa";
+import Link from "next/link";
 import React from "react";
 
 export default function CardSetionOne({ data }: CardSectionProps) {
@@ -16,20 +17,48 @@ export default function CardSetionOne({ data }: CardSectionProps) {
         </div>
       </div>
       <div className="w-[90%] mx-auto">
-        <h1 className="font-bold text-[1.6rem]">{data.title}</h1>
+        <Link
+          href={{
+            pathname: "/article",
+            query: {
+              title: data.title,
+              content: data.content,
+              urlToImage: data.urlToImage,
+              publishedAt: data.publishedAt,
+              publishName: data.source.name,
+              url: data.url,
+            },
+          }}
+        >
+          <h1 className="font-bold text-[1.6rem] hover:underline">
+            {data.title}
+          </h1>
+        </Link>
         <span className="flex my-4 text-gray-600">
           <p className="mr-2 font-bold text-orange-300">{data.source.name}</p>
           {`| ${DateFormat(data.publishedAt)}`}
         </span>
       </div>
       <div className="relative w-[90%] mx-auto">
-        <img
-          src={data.urlToImage}
-          width="200"
-          height="100"
-          alt="news Image"
-          style={{ objectFit: "cover", width: "100%", height: "auto" }}
-        />
+        <Link
+          href={{
+            pathname: "/article",
+            query: {
+              title: data.title,
+              content: data.content,
+              urlToImage: data.urlToImage,
+              publishedAt: data.publishedAt,
+              publishName: data.source.name,
+              url: data.url,
+            },
+          }}
+        >
+          <img
+            src={data.urlToImage}
+            alt="news Image"
+            className="object-cover w-full h-full rounded-md"
+          />
+        </Link>
       </div>
     </div>
   );

--- a/app/components/card/setionThree/cardSetion.tsx
+++ b/app/components/card/setionThree/cardSetion.tsx
@@ -1,26 +1,43 @@
 import { CardSectionProps } from "@/app/types/news";
 import { DateFormat } from "@/app/utils/dateFormat";
+import Link from "next/link";
 import React from "react";
 import { TextLimit } from "@/app/utils/textLimit";
 
 export default function CardSetion({ data }: CardSectionProps) {
   return (
     <div className="relative w-[40%] h-[300px] mx-auto pr-2 py-2">
-      <img
-        src={data.urlToImage}
-        alt="news Image"
-        className="absolute inset-0 w-full h-full object-cover"
-        style={{
-          filter: "brightness(50%)",
+      <Link
+        href={{
+          pathname: "/article",
+          query: {
+            title: data.title,
+            content: data.content,
+            urlToImage: data.urlToImage,
+            publishedAt: data.publishedAt,
+            publishName: data.source.name,
+            url: data.url,
+          },
         }}
-      />
-      <div className="absolute inset-0 flex flex-col justify-end items-center pb-8 text-white">
-        <h1 className="font-bold text-[1.2rem]">{TextLimit(data.title, 40)}</h1>
-        <span className="flex my-4 text-white">
-          <p className="mr-2 font-bold">{data.source.name}</p>
-          {`| ${DateFormat(data.publishedAt)}`}
-        </span>
-      </div>
+      >
+        <img
+          src={data.urlToImage}
+          alt="news Image"
+          className="absolute inset-0 w-full h-full object-cover"
+          style={{
+            filter: "brightness(50%)",
+          }}
+        />
+        <div className="absolute inset-0 flex flex-col justify-end items-center pb-8 text-white">
+          <h1 className="font-bold text-[1.2rem]">
+            {TextLimit(data.title, 40)}
+          </h1>
+          <span className="flex my-4 text-white">
+            <p className="mr-2 font-bold">{data.source.name}</p>
+            {`| ${DateFormat(data.publishedAt)}`}
+          </span>
+        </div>
+      </Link>
     </div>
   );
 }

--- a/app/components/card/setionTwo/cardSetion.tsx
+++ b/app/components/card/setionTwo/cardSetion.tsx
@@ -1,28 +1,57 @@
 import { CardSectionProps } from "@/app/types/news";
 import { DateFormat } from "@/app/utils/dateFormat";
+import Link from "next/link";
 import React from "react";
 
 export default function CardSetion({ data }: CardSectionProps) {
   return (
     <section className="flex w-[90%] mx-auto">
       <div className="pl-2 py-2 w-[60%]">
-        <div className="font-bold">{data.title}</div>
-        <div className="my-2 text-gray-600 text-[0.9rem]">
-          {data.description}
-        </div>
+        <Link
+          href={{
+            pathname: "/article",
+            query: {
+              title: data.title,
+              content: data.content,
+              urlToImage: data.urlToImage,
+              publishedAt: data.publishedAt,
+              publishName: data.source.name,
+              url: data.url,
+            },
+          }}
+        >
+          <div className="font-bold hover:underline">{data.title}</div>
+          <div className="my-2 text-gray-600 text-[0.9rem] hover:underline">
+            {data.description}
+          </div>
+        </Link>
         <span className="flex my-4 text-gray-600">
           <p className="mr-2 font-bold text-orange-300">{data.source.name}</p>
           {`| ${DateFormat(data.publishedAt)}`}
         </span>
       </div>
       <div className="relative w-[35%] h-[180px] mx-auto pr-2 py-2">
-        <img
-          src={data.urlToImage}
-          width="200"
-          height="100"
-          alt="news Image"
-          className="object-cover w-full h-full rounded-md"
-        />
+        <Link
+          href={{
+            pathname: "/article",
+            query: {
+              title: data.title,
+              content: data.content,
+              urlToImage: data.urlToImage,
+              publishedAt: data.publishedAt,
+              publishName: data.source.name,
+              url: data.url,
+            },
+          }}
+        >
+          <img
+            src={data.urlToImage}
+            width="200"
+            height="100"
+            alt="news Image"
+            className="object-cover w-full h-full rounded-md"
+          />
+        </Link>
       </div>
     </section>
   );

--- a/app/components/singleNewsDataForm/singleNewsDataForm.tsx
+++ b/app/components/singleNewsDataForm/singleNewsDataForm.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function SingleNewsDataForm() {
+  return <div>singleNewsDataForm</div>;
+}

--- a/app/search/[search]/page.tsx
+++ b/app/search/[search]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 
+import Link from "next/link";
 import Loading from "@/app/components/loading";
 import { NewsData } from "@/app/types/news";
 import { SearchNewsData } from "@/app/data/searchNewsData";
@@ -33,20 +34,55 @@ export default function SearchPage() {
   if (isLoading) return <Loading />;
   if (data.length === 0) return <p>No articles found</p>;
 
+  console.log(data);
+
   return (
     <div>
       {data.map((article: NewsData, index) => (
         <div key={index} className="border py-6 px-4 rounded-md flex">
-          <div className="w-[60%] px-4">
-            <h2 className="text-[1.4rem] font-bold mb-4">{article.title}</h2>
-            <p>{article.description}</p>
+          <div className="w-[60%] px-4 flex flex-col justify-between">
+            <Link
+              href={{
+                pathname: "/article",
+                query: {
+                  title: article.title,
+                  content: article.content,
+                  urlToImage: article.urlToImage,
+                  publishedAt: article.publishedAt,
+                  publishName: article.source.name,
+                  url: article.url,
+                },
+              }}
+            >
+              <div>
+                <h2 className="text-[1.4rem] font-bold mb-4 hover:underline">
+                  {article.title}
+                </h2>
+                <p className="hover:underline">{article.description}</p>
+              </div>
+            </Link>
+            <p className="font-bold text-blue-600">{article.source.name}</p>
           </div>
           <div className="relative w-[40%] h-[300px]">
-            <img
-              src={article.urlToImage}
-              alt="news Image"
-              className="w-full h-full object-cover rounded-md"
-            />
+            <Link
+              href={{
+                pathname: "/article",
+                query: {
+                  title: article.title,
+                  content: article.content,
+                  urlToImage: article.urlToImage,
+                  publishedAt: article.publishedAt,
+                  publishName: article.source.name,
+                  url: article.url,
+                },
+              }}
+            >
+              <img
+                src={article.urlToImage}
+                alt="news Image"
+                className="w-full h-full object-cover rounded-md"
+              />
+            </Link>
           </div>
         </div>
       ))}


### PR DESCRIPTION
#### 1. 개별 기사 페이지 생성
- 기사마다 고유 id가 없어 필수 정보들만 params에 포함하여 데이터를 전달해서 사용
- 기존 기사들에 제목, 설명, 이미지 클릭시 개별 기사 페이지로 이동
- 실제 뉴스 url 클릭시 해당 기사 본문으로 이동
- 검색 페이지, 카테고리 페이지 개별 Link연동