### PR TITLE
메인 페이지 실시간 데이터에서 최초 데이터 렌더링으로 코드 변경

### DIFF
--- a/app/components/ui/mainPost.tsx
+++ b/app/components/ui/mainPost.tsx
@@ -2,12 +2,10 @@
 
 import CardSetionOne from "../card/setionOne/cardSetionOne";
 import CardSetionTwo from "../card/setionTwo/cardSetionTwo";
-import Loading from "../loading";
 import { NewsData } from "@/app/types/news";
 import NonData from "./nonData";
 import React from "react";
 import dynamic from "next/dynamic";
-import { useQuery } from "@tanstack/react-query";
 
 const CardSetionThree = dynamic(
   () => import("../card/setionThree/cardSetionThree")
@@ -16,16 +14,14 @@ const CardSetionFour = dynamic(
   () => import("../card/setionFour/cardSetionFour")
 );
 
-export default function MainPost() {
-  const { data, isLoading, isError } = useQuery<NewsData[]>({
-    queryKey: ["HeadLineNewsData"],
-  });
+interface MainPostProps {
+  initialData: NewsData[] | undefined;
+}
 
-  if (isLoading) {
-    return <Loading />;
-  }
+export default function MainPost({ initialData }: MainPostProps) {
+  const data = initialData ?? [];
 
-  if (isError || !data || data.length === 0) {
+  if (data.length === 0) {
     return <NonData />;
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import {
 
 import { HeadLineNewsData } from "./data/headLineNewsData";
 import MainPost from "./components/ui/mainPost";
+import { NewsData } from "@/app/types/news";
 
 export default async function Home() {
   const queryClient = new QueryClient();
@@ -15,9 +16,13 @@ export default async function Home() {
     queryFn: HeadLineNewsData,
   });
 
+  const initialData = queryClient.getQueryData<NewsData[]>([
+    "HeadLineNewsData",
+  ]);
+
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <MainPost />
+      <MainPost initialData={initialData} />
     </HydrationBoundary>
   );
 }


### PR DESCRIPTION
#### Vercel에 배포 시 최초 데이터만 사용 됨(정적 페이지)
#### 전체를 바꾸기 보다는 메인 페이지에 데이터 사용방식을 실시간 데이터에서 최초 데이터를 계속 사용하는 방식으로 임시 변경