### PR TITLE
next/img태그 기존 img태그로 변경

### DIFF
--- a/app/(routes)/article/components/articlePost.tsx
+++ b/app/(routes)/article/components/articlePost.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { DateFormat } from "@/app/utils/dateFormat";
-import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 
@@ -20,12 +19,15 @@ export default function ArticlePost() {
       <h1 className="text-[2rem] font-bold mb-8">{title}</h1>
       {urlToImage && (
         <div className="relative w-full h-[400px] mx-auto mb-4">
-          <Image
+          <img
             src={urlToImage}
             alt="news Image"
-            fill
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-            className="object-cover rounded-md"
+            loading="lazy"
+            className="object-cover w-full h-full rounded-md"
+            style={{
+              aspectRatio: "16 / 9",
+              objectFit: "cover",
+            }}
           />
         </div>
       )}

--- a/app/(routes)/search/[search]/page.tsx
+++ b/app/(routes)/search/[search]/page.tsx
@@ -1,4 +1,5 @@
 import Loading from "@/app/components/loading";
+import NonData from "@/app/components/ui/nonData";
 import { SearchNewsData } from "@/app/data/searchNewsData";
 import SearchSection from "../components/searchSection";
 import { Suspense } from "react";
@@ -10,6 +11,10 @@ export default async function SearchPage({
 }) {
   const searchWord = (await params).search;
   const newsData = await SearchNewsData(searchWord);
+
+  if (newsData.length === 0) {
+    return <NonData />;
+  }
 
   return (
     <main>

--- a/app/components/card/setionFour/cardSetion.tsx
+++ b/app/components/card/setionFour/cardSetion.tsx
@@ -2,7 +2,6 @@ import ArticleLink from "../../articleLink";
 import { CardSectionProps } from "@/app/types/news";
 import { DateFormat } from "@/app/utils/dateFormat";
 import { FaUserCircle } from "react-icons/fa";
-import Image from "next/image";
 import React from "react";
 import { TextLimit } from "@/app/utils/textLimit";
 

--- a/app/components/card/setionFour/cardSetion.tsx
+++ b/app/components/card/setionFour/cardSetion.tsx
@@ -11,12 +11,11 @@ export default function CardSetion({ data }: CardSectionProps) {
     <section className="py-4">
       <div className="relative w-[20rem] h-[15rem] mx-auto">
         <ArticleLink data={data}>
-          <Image
+          <img
             src={data.urlToImage}
             alt="news Image"
-            layout="fill"
-            objectFit="cover"
-            className="rounded-md"
+            loading="lazy"
+            className="absolute inset-0 w-full h-full object-cover brightness-50"
           />
         </ArticleLink>
       </div>

--- a/app/components/card/setionOne/cardSetionOne.tsx
+++ b/app/components/card/setionOne/cardSetionOne.tsx
@@ -2,10 +2,10 @@ import ArticleLink from "../../articleLink";
 import { CardSectionProps } from "@/app/types/news";
 import { DateFormat } from "@/app/utils/dateFormat";
 import { FaUserCircle } from "react-icons/fa";
-import Image from "next/image";
 import React from "react";
 
 const CardSetionOne = React.memo(({ data }: CardSectionProps) => {
+  console.log(data.urlToImage);
   return (
     <article className="w-[50%] h-[44rem] p-4">
       <header className="flex items-center w-[90%] mx-auto">
@@ -30,13 +30,15 @@ const CardSetionOne = React.memo(({ data }: CardSectionProps) => {
       </section>
       <section className="relative w-[90%] h-[27rem] mx-auto">
         <ArticleLink data={data}>
-          <Image
+          <img
             src={data.urlToImage}
             alt="news Image"
-            fill
-            priority
+            loading="lazy"
             className="object-cover w-full h-full rounded-md"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            style={{
+              aspectRatio: "16 / 9",
+              objectFit: "cover",
+            }}
           />
         </ArticleLink>
       </section>

--- a/app/components/card/setionThree/cardSetion.tsx
+++ b/app/components/card/setionThree/cardSetion.tsx
@@ -1,7 +1,6 @@
 import ArticleLink from "../../articleLink";
 import { CardSectionProps } from "@/app/types/news";
 import { DateFormat } from "@/app/utils/dateFormat";
-import Image from "next/image";
 import React from "react";
 import { TextLimit } from "@/app/utils/textLimit";
 
@@ -9,12 +8,11 @@ export default function CardSetion({ data }: CardSectionProps) {
   return (
     <section className="relative w-[35rem] h-[26.25rem] mx-auto pr-2 py-2">
       <ArticleLink data={data}>
-        <Image
+        <img
           src={data.urlToImage}
           alt="news Image"
-          layout="fill"
-          objectFit="cover"
-          className="brightness-50"
+          loading="lazy"
+          className="absolute inset-0 w-full h-full object-cover brightness-50"
         />
         <div className="absolute inset-0 flex flex-col justify-end items-center pb-8 text-white">
           <h1 className="font-bold text-[1.2rem]">

--- a/app/components/card/setionTwo/cardSetion.tsx
+++ b/app/components/card/setionTwo/cardSetion.tsx
@@ -1,7 +1,6 @@
 import ArticleLink from "../../articleLink";
 import { CardSectionProps } from "@/app/types/news";
 import { DateFormat } from "@/app/utils/dateFormat";
-import Image from "next/image";
 import React from "react";
 import { TextLimit } from "@/app/utils/textLimit";
 
@@ -22,14 +21,15 @@ export default function CardSetion({ data }: CardSectionProps) {
       </div>
       <div className="relative w-[13rem] h-[10rem] mx-auto pr-2 py-2">
         <ArticleLink data={data}>
-          <Image
+          <img
             src={data.urlToImage}
             alt="news Image"
-            width={200}
-            height={180}
-            priority
+            loading="lazy"
             className="object-cover w-full h-full rounded-md"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            style={{
+              aspectRatio: "16 / 9",
+              objectFit: "cover",
+            }}
           />
         </ArticleLink>
       </div>

--- a/app/components/ui/detailPost.tsx
+++ b/app/components/ui/detailPost.tsx
@@ -1,5 +1,4 @@
 import ArticleLink from "@/app/components/articleLink";
-import Image from "next/image";
 import { NewsData } from "@/app/types/news";
 import React from "react";
 
@@ -16,13 +15,15 @@ const DetailPost = React.memo(({ data }: { data: NewsData }) => (
     </header>
     <section className="relative w-[40%] h-[20rem]">
       <ArticleLink data={data}>
-        <Image
+        <img
           src={data.urlToImage}
           alt="news Image"
-          fill
-          priority
+          loading="lazy"
           className="object-cover w-full h-full rounded-md"
-          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+          style={{
+            aspectRatio: "16 / 9",
+            objectFit: "cover",
+          }}
         />
       </ArticleLink>
     </section>


### PR DESCRIPTION

Vercel 배포시 next/img태그를 Vercel에서 제공하는 제한 횟수가 존재하기에 배포 사이트에 이미지가 나오지 않는 에러 발견
- next/img 대신 기존 img로 변경후 lazy loading을 직접 적용
